### PR TITLE
ci: add GHCR Docker build & push deploy step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,5 +67,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Placeholder deploy step
-        run: echo "Add deploy steps here (e.g., docker build & push, or cloud deploy)"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image (apps/api)
+        uses: docker/build-push-action@v4
+        with:
+          context: ./apps/api
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/app-kirimku-id:latest


### PR DESCRIPTION
Adds Docker buildx & push to GitHub Container Registry (GHCR) for apps/api using GITHUB_TOKEN.

## Summary by Sourcery

Automate the building and publishing of the apps/api Docker image to GitHub Container Registry within the CI workflow.

CI:
- Add steps to set up QEMU and Docker Buildx in CI
- Log in to GitHub Container Registry using GITHUB_TOKEN
- Build and push the apps/api Docker image to GHCR