### PR TITLE
ci: tag Docker image with latest + SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,5 +67,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Placeholder deploy step
-        run: echo "Add deploy steps here (e.g., docker build & push, or cloud deploy)"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image (apps/api)
+        uses: docker/build-push-action@v4
+        with:
+          context: ./apps/api
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/app-kirimku-id:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,4 +85,6 @@ jobs:
         with:
           context: ./apps/api
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/app-kirimku-id:latest
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/app-kirimku-id:latest
+            ghcr.io/${{ github.repository_owner }}/app-kirimku-id:${{ github.sha }}


### PR DESCRIPTION
Add image tagging so deploy pushes both latest and commit-SHA tags to GHCR.

## Summary by Sourcery

Configure CI to build and push the Docker image to GitHub Container Registry with both latest and commit SHA tags

Build:
- Build and push the apps/api Docker image tagged as latest and with the current commit SHA

CI:
- Add QEMU and Buildx setup steps for cross-platform Docker builds
- Authenticate to GitHub Container Registry using GITHUB_TOKEN