### PR TITLE
ci: add release workflow + GHCR monitor

### DIFF
--- a/.github/workflows/monitor-ghcr.yml
+++ b/.github/workflows/monitor-ghcr.yml
@@ -1,0 +1,30 @@
+name: Monitor GHCR
+
+on:
+  schedule:
+    - cron: '0 3 * * *' # daily at 03:00 UTC
+
+jobs:
+  check-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Attempt to pull latest image
+        id: pull
+        run: |
+          set -e
+          echo "Trying to pull ghcr.io/${{ github.repository_owner }}/app-kirimku-id:latest"
+          docker pull ghcr.io/${{ github.repository_owner }}/app-kirimku-id:latest || exit 1
+
+  report:
+    needs: check-image
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - name: Create issue when image pull fails
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: "Monitor: GHCR image pull failed"
+          content: |
+            The scheduled GHCR monitor failed to pull the latest image for `app-kirimku-id`.
+            Please check the Actions run logs and GHCR package settings.
+          labels: bug, infra

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image (apps/api)
+        uses: docker/build-push-action@v4
+        with:
+          context: ./apps/api
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/app-kirimku-id:${{ github.ref_name }}
+            ghcr.io/${{ github.repository_owner }}/app-kirimku-id:latest
+
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          body: "Release created from tag ${{ github.ref_name }} by CI"


### PR DESCRIPTION
Adds a release workflow that builds/pushes Docker image on tag and creates a GitHub Release, and a scheduled monitor that verifies GHCR image pullability.

## Summary by Sourcery

Add GitHub Actions workflows to automate Docker image releases on tag creation and to monitor GHCR image pullability.

CI:
- Add release workflow triggered by v* tags to build and push Docker images and create GitHub Releases
- Add daily scheduled workflow to verify GHCR image pullability and create an issue on failures