### PR TITLE
ci: add manual GHCR monitor

### DIFF
--- a/.github/workflows/monitor-manual.yml
+++ b/.github/workflows/monitor-manual.yml
@@ -1,0 +1,39 @@
+name: Monitor GHCR (manual)
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  check-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PAT }}
+
+      - name: Attempt to pull latest image
+        id: pull
+        run: |
+          set -e
+          echo "Trying to pull ghcr.io/${{ github.repository_owner }}/app-kirimku-id:latest"
+          docker pull ghcr.io/${{ github.repository_owner }}/app-kirimku-id:latest || exit 1
+
+  report:
+    needs: check-image
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - name: Create issue when image pull fails
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: "Monitor: GHCR image pull failed (manual run)"
+          content: |
+            The manual GHCR monitor run failed to pull the latest image for `app-kirimku-id`.
+            Please check the Actions run logs and GHCR package settings.
+          labels: bug, infra


### PR DESCRIPTION
Adds a workflow_dispatch manual GHCR monitor so we can run the pull check on demand.

## Summary by Sourcery

Introduce a manual GitHub Actions workflow to monitor the GHCR image by attempting to pull the latest container on demand and opening an issue if the pull fails.

CI:
- Add monitor-manual.yml workflow with workflow_dispatch trigger to run the GHCR pull check.
- Implement a job to log in, pull the latest app-kirimku-id image, and exit on failure.
- Add a conditional report job to create a GitHub issue when the image pull fails.